### PR TITLE
게시글 태그 포함해서 작성

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.8</version>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @CrossOrigin
 @RequiredArgsConstructor
 @Tag(name = "Board", description = "게시글 관련 API")
-@RequestMapping("/api/boards")
+@RequestMapping("/boards")
 @RestController
 public class BoardController {
 

--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@CrossOrigin
 @RequiredArgsConstructor
 @Tag(name = "Board", description = "게시글 관련 API")
 @RequestMapping("/api/boards")
@@ -18,13 +19,11 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @CrossOrigin
     @PostMapping
     @Operation(summary = "게시글 작성",
             description = "게시글을 작성하고, 해당 게시글의 해시태그도 소문자로 변환하여 저장합니다.")
     public ResponseEntity<CreateBoardResponseDto> createBoard(@Valid @RequestBody CreateBoardRequestDto boardRequestDto) {
         // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져올 예정
-        //  security에서 cors 설정할 수 있으므로 임시로 @CrossOrigin 사용
         CreateBoardResponseDto boardResponseDto = boardService.createBoard(boardRequestDto);
         return ResponseEntity.ok(boardResponseDto);
     }

--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -1,0 +1,32 @@
+package com.example.study_monster_back.board.controller;
+
+import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
+import com.example.study_monster_back.board.service.BoardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@Tag(name = "Board", description = "게시글 관련 API")
+@RequestMapping("/api/boards")
+@RestController
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @CrossOrigin
+    @PostMapping
+    @Operation(summary = "게시글 작성",
+            description = "게시글을 작성하고, 해당 게시글의 해시태그도 소문자로 변환하여 저장합니다.")
+    public ResponseEntity<CreateBoardResponseDto> createBoard(@Valid @RequestBody CreateBoardRequestDto boardRequestDto) {
+        // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져올 예정
+        //  security에서 cors 설정할 수 있으므로 임시로 @CrossOrigin 사용
+        CreateBoardResponseDto boardResponseDto = boardService.createBoard(boardRequestDto);
+        return ResponseEntity.ok(boardResponseDto);
+    }
+
+}

--- a/src/main/java/com/example/study_monster_back/board/dto/request/CreateBoardRequestDto.java
+++ b/src/main/java/com/example/study_monster_back/board/dto/request/CreateBoardRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.study_monster_back.board.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBoardRequestDto {
+
+    @NotBlank(message = "제목은 필수입니다")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다")
+    private String content;
+
+    private Long userId;
+
+    private List<String> tags;
+}

--- a/src/main/java/com/example/study_monster_back/board/dto/response/CreateBoardResponseDto.java
+++ b/src/main/java/com/example/study_monster_back/board/dto/response/CreateBoardResponseDto.java
@@ -1,0 +1,39 @@
+package com.example.study_monster_back.board.dto.response;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
+import com.example.study_monster_back.user.dto.response.UserSummaryResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBoardResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private UserSummaryResponseDto user;
+    private List<TagResponseDto> tags;
+    private LocalDateTime created_at;
+
+    public static CreateBoardResponseDto from(Board board) {
+        return CreateBoardResponseDto.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .user(UserSummaryResponseDto.from(board.getUser()))
+                .tags(board.getBoardTags().stream()
+                        .map(boardTag -> TagResponseDto.from(boardTag.getTag()))
+                        .toList())
+                .created_at(board.getCreated_at())
+                .build();
+    }
+}

--- a/src/main/java/com/example/study_monster_back/board/entity/Board.java
+++ b/src/main/java/com/example/study_monster_back/board/entity/Board.java
@@ -1,35 +1,51 @@
 package com.example.study_monster_back.board.entity;
 
-import java.time.LocalDateTime;
-
+import com.example.study_monster_back.tag.entity.BoardTag;
+import com.example.study_monster_back.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import com.example.study_monster_back.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import lombok.Data;
-
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @Data
-public class Board{
+public class Board {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;
+
+    @Column(columnDefinition = "TEXT")
     private String content;
+
     @CreatedDate
     private LocalDateTime created_at;
+
     @LastModifiedDate
     private LocalDateTime updated_at;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
-    
+
+    @Builder.Default
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardTag> boardTags = new ArrayList<>();
+
+    public void addBoardTag(BoardTag boardTag) {
+        boardTags.add(boardTag);
+    }
+
 }

--- a/src/main/java/com/example/study_monster_back/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/study_monster_back/board/repository/BoardRepository.java
@@ -1,0 +1,15 @@
+package com.example.study_monster_back.board.repository;
+
+import com.example.study_monster_back.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    @Query("SELECT b FROM Board b LEFT JOIN FETCH b.boardTags bt LEFT JOIN FETCH bt.tag Where b.id = :id")
+    Optional<Board> findByIdWithTags(@Param("id") Long id);
+
+}

--- a/src/main/java/com/example/study_monster_back/board/service/BoardService.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardService.java
@@ -1,0 +1,9 @@
+package com.example.study_monster_back.board.service;
+
+import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
+
+public interface BoardService {
+
+    CreateBoardResponseDto createBoard(CreateBoardRequestDto boardRequestDto);
+}

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -1,0 +1,55 @@
+package com.example.study_monster_back.board.service;
+
+import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.board.repository.BoardRepository;
+import com.example.study_monster_back.tag.entity.BoardTag;
+import com.example.study_monster_back.tag.entity.Tag;
+
+import com.example.study_monster_back.tag.service.BoardTagService;
+import com.example.study_monster_back.tag.service.TagService;
+import com.example.study_monster_back.tag.util.TagValidator;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.respository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@RequiredArgsConstructor
+@Service
+public class BoardServiceImpl implements BoardService {
+
+    private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final TagService tagService;
+    private final BoardTagService boardTagService;
+    private final TagValidator tagValidator;
+
+    @Transactional
+    public CreateBoardResponseDto createBoard(CreateBoardRequestDto boardRequestDto) {
+
+        // TODO: 추후 수정 예정(지금은 유저 정보를 dto에서 받아옴.)
+        User user = userRepository.findById(boardRequestDto.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + boardRequestDto.getUserId()));
+
+        Board board = Board.builder()
+                .title(boardRequestDto.getTitle())
+                .content(boardRequestDto.getContent())
+                .user(user)
+                .build();
+        boardRepository.save(board);
+
+        for (String tagName : tagValidator.filterValidTags(boardRequestDto.getTags())) {
+            Tag tag = tagService.findOrCreateTag(tagName);
+            BoardTag boardTag = boardTagService.createBoardTag(board, tag);
+            board.addBoardTag(boardTag);
+        }
+
+        Board savedBoard = boardRepository.findByIdWithTags(board.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Board not found with ID: " + board.getId()));
+
+        return CreateBoardResponseDto.from(savedBoard);
+    }
+}

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -11,7 +11,7 @@ import com.example.study_monster_back.tag.service.BoardTagService;
 import com.example.study_monster_back.tag.service.TagService;
 import com.example.study_monster_back.tag.util.TagValidator;
 import com.example.study_monster_back.user.entity.User;
-import com.example.study_monster_back.user.respository.UserRepository;
+import com.example.study_monster_back.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -47,9 +47,6 @@ public class BoardServiceImpl implements BoardService {
             board.addBoardTag(boardTag);
         }
 
-        Board savedBoard = boardRepository.findByIdWithTags(board.getId())
-                .orElseThrow(() -> new IllegalArgumentException("Board not found with ID: " + board.getId()));
-
-        return CreateBoardResponseDto.from(savedBoard);
+        return CreateBoardResponseDto.from(board);
     }
 }

--- a/src/main/java/com/example/study_monster_back/tag/dto/response/TagResponseDto.java
+++ b/src/main/java/com/example/study_monster_back/tag/dto/response/TagResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.study_monster_back.tag.dto.response;
+
+import com.example.study_monster_back.tag.entity.Tag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class TagResponseDto {
+    private Long id;
+    private String name;
+
+    public static TagResponseDto from(Tag tag) {
+        TagResponseDto tagResponseDto = TagResponseDto.builder()
+                .id(tag.getId())
+                .name(tag.getName())
+                .build();
+        return tagResponseDto;
+    }
+}

--- a/src/main/java/com/example/study_monster_back/tag/entity/BoardTag.java
+++ b/src/main/java/com/example/study_monster_back/tag/entity/BoardTag.java
@@ -1,25 +1,28 @@
 package com.example.study_monster_back.tag.entity;
 
 import com.example.study_monster_back.board.entity.Board;
-
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Data
-public class BoardTag{
+public class BoardTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
+
     @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     private Board board;
 
 }

--- a/src/main/java/com/example/study_monster_back/tag/entity/Tag.java
+++ b/src/main/java/com/example/study_monster_back/tag/entity/Tag.java
@@ -4,14 +4,21 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Data
-public class Tag{
+public class Tag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
+
 }

--- a/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
@@ -1,0 +1,7 @@
+package com.example.study_monster_back.tag.repository;
+
+import com.example.study_monster_back.tag.entity.BoardTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
+}

--- a/src/main/java/com/example/study_monster_back/tag/repository/TagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package com.example.study_monster_back.tag.repository;
+
+import com.example.study_monster_back.tag.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/BoardTagService.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/BoardTagService.java
@@ -1,0 +1,12 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.tag.entity.BoardTag;
+import com.example.study_monster_back.tag.entity.Tag;
+
+
+public interface BoardTagService {
+
+    BoardTag createBoardTag(Board board, Tag tag);
+
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/BoardTagServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/BoardTagServiceImpl.java
@@ -1,0 +1,27 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.tag.entity.BoardTag;
+import com.example.study_monster_back.tag.entity.Tag;
+import com.example.study_monster_back.tag.repository.BoardTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class BoardTagServiceImpl implements BoardTagService {
+
+    private final BoardTagRepository boardTagRepository;
+
+    public BoardTag createBoardTag(Board board, Tag tag) {
+        BoardTag boardTag = BoardTag.builder()
+                .board(board)
+                .tag(tag)
+                .build();
+        return boardTagRepository.save(boardTag);
+    }
+
+
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/TagService.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/TagService.java
@@ -1,0 +1,8 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.tag.entity.Tag;
+
+public interface TagService {
+
+    Tag findOrCreateTag(String tagName);
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/TagServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.tag.entity.Tag;
+import com.example.study_monster_back.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TagServiceImpl implements TagService {
+
+    private final TagRepository tagRepository;
+
+    public Tag findOrCreateTag(String tagName) {
+        return tagRepository.findByName(tagName)
+                .orElseGet(() -> {
+                    Tag newTag = Tag.builder().name(tagName).build();
+                    return tagRepository.save(newTag);
+                });
+    }
+
+}

--- a/src/main/java/com/example/study_monster_back/tag/util/TagValidator.java
+++ b/src/main/java/com/example/study_monster_back/tag/util/TagValidator.java
@@ -1,0 +1,41 @@
+package com.example.study_monster_back.tag.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Component
+public class TagValidator {
+
+    private static final int MAX_TAG_LENGTH = 50;
+    private static final Pattern TAG_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣_#.+]+$");
+
+    public boolean isValidTagName(String tagName) {
+
+        if (tagName == null || tagName.trim().length() == 0) {
+            return false;
+        }
+
+        if (tagName.length() > MAX_TAG_LENGTH) {
+            return false;
+        }
+
+        return tagName.matches(TAG_PATTERN.pattern());
+    }
+
+    public Set<String> filterValidTags(List<String> rawTags) {
+
+        if (rawTags == null) {
+            return new HashSet<>();
+        }
+
+        return rawTags.stream()
+                .filter(this::isValidTagName)
+                .map(tag -> tag.toLowerCase().trim())
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/com/example/study_monster_back/user/dto/response/UserSummaryResponseDto.java
+++ b/src/main/java/com/example/study_monster_back/user/dto/response/UserSummaryResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.study_monster_back.user.dto.response;
+
+import com.example.study_monster_back.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserSummaryResponseDto {
+    private Long userId;
+    private String nickname;
+
+    public static UserSummaryResponseDto from(User user) {
+        UserSummaryResponseDto userSummaryResponseDto = UserSummaryResponseDto.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+        return userSummaryResponseDto;
+    }
+}

--- a/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
+++ b/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
@@ -1,4 +1,4 @@
-package com.example.study_monster_back.user.respository;
+package com.example.study_monster_back.user.repository;
 
 import com.example.study_monster_back.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/example/study_monster_back/user/respository/UserRepository.java
+++ b/src/main/java/com/example/study_monster_back/user/respository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.study_monster_back.user.respository;
+
+import com.example.study_monster_back.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
@@ -1,0 +1,94 @@
+package com.example.study_monster_back.board.service;
+
+import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.board.repository.BoardRepository;
+import com.example.study_monster_back.tag.repository.TagRepository;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.respository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+@DisplayName("BoardService 테스트")
+public class BoardServiceTest {
+
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Test
+    void 게시글_생성_요청시_게시글과_태그가_함께_저장된다() {
+        // given
+        User user = createAndSaveUser();
+
+        CreateBoardRequestDto requestDto = new CreateBoardRequestDto(
+                "테스트 제목",
+                "테스트 내용",
+                user.getId(),
+                Arrays.asList("태그1", "태그2", "tag3")
+        );
+
+        // when
+        CreateBoardResponseDto responseDto = boardService.createBoard(requestDto);
+
+        // then
+        // responseDto 검증
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getTitle()).isEqualTo(requestDto.getTitle());
+        assertThat(responseDto.getContent()).isEqualTo(requestDto.getContent());
+        assertThat(responseDto.getUser().getUserId()).isEqualTo(user.getId());
+        assertThat(responseDto.getTags().size()).isEqualTo(requestDto.getTags().size());
+
+        // 저장된 게시글 검증
+        Board savedBoard = boardRepository.findByIdWithTags(responseDto.getId())
+                .orElseThrow(() -> new AssertionError("게시글이 저장되지 않았습니다."));
+
+        assertThat(savedBoard.getTitle()).isEqualTo(requestDto.getTitle());
+        assertThat(savedBoard.getContent()).isEqualTo(requestDto.getContent());
+        assertThat(savedBoard.getUser().getId()).isEqualTo(user.getId());
+        assertThat(savedBoard.getBoardTags().size()).isEqualTo(responseDto.getTags().size());
+
+        // 태그 검증
+        List<String> tagNames = savedBoard.getBoardTags().stream()
+                .map(boardTag -> boardTag.getTag().getName())
+                .toList();
+
+        assertTrue(tagNames.contains("태그1"));
+        assertTrue(tagNames.contains("태그2"));
+        assertTrue(tagNames.contains("tag3"));
+    }
+
+
+    private User createAndSaveUser() {
+
+        User user = new User();
+        user.setNickname("testUser");
+        user.setEmail("test@example.com");
+        user.setName("Test User");
+        user.setPwd("password");
+        user.setRole("USER");
+        user.setPhone_number("010-0000-5678");
+
+        return userRepository.save(user);
+    }
+}

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
@@ -6,7 +6,7 @@ import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.board.repository.BoardRepository;
 import com.example.study_monster_back.tag.repository.TagRepository;
 import com.example.study_monster_back.user.entity.User;
-import com.example.study_monster_back.user.respository.UserRepository;
+import com.example.study_monster_back.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/example/study_monster_back/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/com/example/study_monster_back/tag/repository/TagRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.example.study_monster_back.tag.repository;
+
+import com.example.study_monster_back.tag.entity.Tag;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+@DisplayName("TagRepository 테스트")
+public class TagRepositoryTest {
+
+    @Autowired
+    private TagRepository tagRepository;
+
+
+    @Test
+    void 존재하는_태그를_찾으면_해당_태그를_반환한다() {
+        //given
+        String tagName = "existing";
+        Tag tag = Tag.builder().name(tagName).build();
+        tagRepository.save(tag);
+
+        //when
+        Optional<Tag> foundTag = tagRepository.findByName(tagName);
+
+        //then
+        assertTrue(foundTag.isPresent());
+        assertEquals(tagName, foundTag.get().getName());
+    }
+
+    @Test
+    void 존재하지_않는_태그를_찾으면_비어있는_값을_반환한다() {
+        //given
+        String nonExistingTagName = "nonexisting";
+
+        //when
+        Optional<Tag> foundTag = tagRepository.findByName(nonExistingTagName);
+
+        //then
+        assertTrue(foundTag.isEmpty());
+    }
+}

--- a/src/test/java/com/example/study_monster_back/tag/service/TagServiceImplTest.java
+++ b/src/test/java/com/example/study_monster_back/tag/service/TagServiceImplTest.java
@@ -1,0 +1,61 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.tag.entity.Tag;
+import com.example.study_monster_back.tag.repository.TagRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+@Transactional
+@DisplayName("TagService 테스트")
+public class TagServiceImplTest {
+    @Autowired
+    private TagService tagService;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Test
+    @DisplayName("존재하는 태그를 찾으면 해당 태그를 반환한다")
+    void 존재하는_태그를_찾으면_해당_태그를_반환한다() {
+        // given
+        String tagName = "existing";
+        Tag tag = Tag.builder().name(tagName).build();
+        tagRepository.save(tag);
+
+        // when
+        Tag result = tagService.findOrCreateTag(tagName);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(tagName);
+        assertThat(result.getId()).isEqualTo(tag.getId());
+    }
+
+    @Test
+    void 존재하지_않는_태그는_새로_생성하여_반환한다() {
+        // given
+        String tagName = "newTag";
+
+        // when
+        Tag result = tagService.findOrCreateTag(tagName);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(tagName);
+        assertThat(result.getId()).isNotNull();
+
+
+        Optional<Tag> savedTag = tagRepository.findByName(tagName);
+        assertThat(savedTag).isPresent();
+        assertThat(savedTag.get().getId()).isEqualTo(result.getId());
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 게시글 저장시 태그도 함께 저장.
- 게시글 조회 시 태그도 같이 조회하는 것이 좋을 것 같아 Board와 BoardTag 양방향 매핑 설정.
- 양방향 매핑으로 인한 순환 참조를 방지하기 위해 @JsonIgnore 사용.

## 연관된 이슈
- #5 

## 스크린샷 (선택)
- 없음.

## 특이사항(선택)
- Swagger를 추가했습니다. 추후에 형식을 맞추면 좋을 것 같습니다.
- Spring Security 부분 구현이 완료되면 유저 정보를 시큐리티 컨텍스트에서 불러오는 것으로 수정할 예정입니다.
- 글과 태그 저장을 한번에 하고, 추후에 게시글을 불러올 때도 태그를 한번에 가져오는게 좋을 것 같아서 Board와 BoardTag 양방향 매핑을 설정했습니다. 글 저장 api와 태그 저장 api를 분리하는 것이 좋을까요?
