### PR TITLE
스터디 그룹 생성 페이지 구현

### DIFF
--- a/src/main/java/com/example/study_monster_back/StudyMonsterBackApplication.java
+++ b/src/main/java/com/example/study_monster_back/StudyMonsterBackApplication.java
@@ -3,9 +3,11 @@ package com.example.study_monster_back;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class StudyMonsterBackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
@@ -1,17 +1,23 @@
 package com.example.study_monster_back.group.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.study_monster_back.group.dto.StudyGroupRequestDTO;
 import com.example.study_monster_back.group.dto.StudyGroupResponseDTO;
 import com.example.study_monster_back.group.service.StudyGroupService;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 
 @CrossOrigin(origins = "http://localhost:5173")
@@ -27,5 +33,16 @@ public class StudyGroupController {
         List<StudyGroupResponseDTO> studyGroups = studyGroupService.getAllStudyGroups();
         return ResponseEntity.ok(studyGroups);
     }
+    @PostMapping("/create")
+    public ResponseEntity<?> createStudyGroup(
+        @RequestBody StudyGroupRequestDTO dto,
+        @RequestParam Long userId) { //아이디는 테스트용
+        studyGroupService.create(dto, userId);
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "스터디 생성 완료");
+
+    return ResponseEntity.ok(response); 
+}
 
 }

--- a/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
@@ -37,12 +37,9 @@ public class StudyGroupController {
     public ResponseEntity<?> createStudyGroup(
         @RequestBody StudyGroupRequestDTO dto,
         @RequestParam Long userId) { //아이디는 테스트용
+
         studyGroupService.create(dto, userId);
-
-    Map<String, String> response = new HashMap<>();
-    response.put("message", "스터디 생성 완료");
-
-    return ResponseEntity.ok(response); 
-}
+        return ResponseEntity.ok(Map.of("message", "스터디 생성 완료"));
+    }
 
 }

--- a/src/main/java/com/example/study_monster_back/group/dto/StudyGroupRequestDTO.java
+++ b/src/main/java/com/example/study_monster_back/group/dto/StudyGroupRequestDTO.java
@@ -1,0 +1,17 @@
+package com.example.study_monster_back.group.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class StudyGroupRequestDTO {
+
+    private String name;
+    private String description;
+    private Integer limit_members;
+    private LocalDateTime deadline;
+    private String nickname;
+    //todo 태그 추후 추가
+    
+}

--- a/src/main/java/com/example/study_monster_back/group/dto/StudyGroupResponseDTO.java
+++ b/src/main/java/com/example/study_monster_back/group/dto/StudyGroupResponseDTO.java
@@ -14,7 +14,7 @@ public class StudyGroupResponseDTO {
 
     private Long id;
     private String name;
-    List<String> tags;
+    private List<String> tagList;
     private LocalDateTime created_at;
     private String description;
     private Integer limit_members;

--- a/src/main/java/com/example/study_monster_back/group/entity/StudyMember.java
+++ b/src/main/java/com/example/study_monster_back/group/entity/StudyMember.java
@@ -4,10 +4,12 @@ package com.example.study_monster_back.group.entity;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.example.study_monster_back.user.entity.User;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,6 +19,7 @@ import lombok.Data;
 
 @Entity
 @Data
+@EntityListeners(AuditingEntityListener.class)
 public class StudyMember{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/study_monster_back/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/example/study_monster_back/group/repository/StudyGroupRepository.java
@@ -1,5 +1,6 @@
 package com.example.study_monster_back.group.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,6 +14,8 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
 
     @Query("SELECT s.studyGroup.id, COUNT(s) FROM StudyMember s GROUP BY s.studyGroup.id")
     List<Object[]> countMembersByStudyGroup();
+
+    List<StudyGroup> findByDeadlineBeforeAndStatus(LocalDateTime now, String string);
 
     
     

--- a/src/main/java/com/example/study_monster_back/group/repository/StudyMemberRepository.java
+++ b/src/main/java/com/example/study_monster_back/group/repository/StudyMemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.study_monster_back.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.study_monster_back.group.entity.StudyMember;
+
+public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
+
+    
+} 

--- a/src/main/java/com/example/study_monster_back/group/scheduler/StudyStatusScheduler.java
+++ b/src/main/java/com/example/study_monster_back/group/scheduler/StudyStatusScheduler.java
@@ -1,0 +1,32 @@
+package com.example.study_monster_back.group.scheduler;
+
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.group.repository.StudyGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StudyStatusScheduler {
+
+    private final StudyGroupRepository studyGroupRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
+    @Transactional
+    public void updateClosedStudyGroups() {
+        List<StudyGroup> expired = studyGroupRepository.findByDeadlineBeforeAndStatus(
+            LocalDateTime.now(), "모집중"
+        );
+
+        for (StudyGroup group : expired) {
+            group.setStatus("모집완료");
+        }
+
+        studyGroupRepository.saveAll(expired);
+    }
+}

--- a/src/main/java/com/example/study_monster_back/group/service/StudyGroupService.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyGroupService.java
@@ -1,8 +1,12 @@
 package com.example.study_monster_back.group.service;
 
 import java.util.List;
+
+import com.example.study_monster_back.group.dto.StudyGroupRequestDTO;
 import com.example.study_monster_back.group.dto.StudyGroupResponseDTO;
 
 public interface StudyGroupService {
     List<StudyGroupResponseDTO> getAllStudyGroups();
+    void create(StudyGroupRequestDTO dto, Long userId);
+
 }

--- a/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
@@ -9,9 +9,16 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.example.study_monster_back.group.dto.StudyGroupRequestDTO;
 import com.example.study_monster_back.group.dto.StudyGroupResponseDTO;
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.group.entity.StudyMember;
 import com.example.study_monster_back.group.repository.StudyGroupRepository;
+import com.example.study_monster_back.group.repository.StudyMemberRepository;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.repository.UserRepository;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -19,6 +26,8 @@ import lombok.RequiredArgsConstructor;
 public class StudyGroupServiceImpl implements StudyGroupService {
 
     private final StudyGroupRepository studyGroupRepository;
+    private final UserRepository userRepository;
+    private final StudyMemberRepository studyMemberRepository;
 
 
     @Override
@@ -61,4 +70,31 @@ public class StudyGroupServiceImpl implements StudyGroupService {
         })
          .collect(Collectors.toList());
     }
+    
+    @Override
+    @Transactional
+    public void create(StudyGroupRequestDTO dto, Long userId) {
+    // 유저 조회
+    User creator = userRepository.findById(userId)
+        .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+    // StudyGroup 생성
+    StudyGroup group = new StudyGroup();
+    group.setName(dto.getName());
+    group.setDescription(dto.getDescription());
+    group.setDeadline(dto.getDeadline());
+    group.setLimit_members(dto.getLimit_members());
+    group.setStatus("모집중"); 
+    group.setCreator(creator); 
+
+    studyGroupRepository.save(group);
+
+    // 3 방장도 멤버
+    StudyMember member = new StudyMember();
+    member.setUser(creator);
+    member.setStudyGroup(group);
+
+    studyMemberRepository.save(member);
+}
+
 }

--- a/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
@@ -53,12 +53,12 @@ public class StudyGroupServiceImpl implements StudyGroupService {
             String status = (isDeadlinePassed || isFull) ? "모집완료" : "모집중";
 
             String formattedDeadline = group.getDeadline().toLocalDate().format(formatter);
-            List<String> tagNames = Arrays.asList("Java", "Spring", "React"); //태그 임시 확인용
+            List<String> tagList = Arrays.asList("Java", "Spring", "React"); //태그 임시 확인용
 
             return new StudyGroupResponseDTO(
                 group.getId(),
                 group.getName(),
-                tagNames,
+                tagList,
                 group.getCreated_at(),        
                 group.getDescription(),       
                 group.getLimit_members(),

--- a/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyGroupServiceImpl.java
@@ -74,9 +74,28 @@ public class StudyGroupServiceImpl implements StudyGroupService {
     @Override
     @Transactional
     public void create(StudyGroupRequestDTO dto, Long userId) {
-    // 유저 조회
-    User creator = userRepository.findById(userId)
+        
+        //사용자 조회
+     User creator = userRepository.findById(userId)
         .orElseThrow(() -> new RuntimeException("사용자 없음"));
+
+
+    if (dto.getLimit_members() < 2) {
+        throw new IllegalArgumentException("모집 인원은 2명 이상이어야 합니다.");
+    }
+
+    if (dto.getDeadline().isBefore(LocalDateTime.now())) {
+        throw new IllegalArgumentException("모집 마감일은 현재 시각 이후여야 합니다.");
+    }
+
+    if (dto.getName() == null || dto.getName().trim().isEmpty()) {
+        throw new IllegalArgumentException("스터디 제목을 입력해 주세요.");
+    }
+
+    if (dto.getDescription() == null || dto.getDescription().trim().isEmpty()) {
+        throw new IllegalArgumentException("스터디 설명을 입력해 주세요.");
+    }
+
 
     // StudyGroup 생성
     StudyGroup group = new StudyGroup();
@@ -96,5 +115,6 @@ public class StudyGroupServiceImpl implements StudyGroupService {
 
     studyMemberRepository.save(member);
 }
+
 
 }

--- a/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
+++ b/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.study_monster_back.user.repository;
+
+
+import com.example.study_monster_back.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/test/java/com/example/study_monster_back/studyGroup/CreateStudyTests.java
+++ b/src/test/java/com/example/study_monster_back/studyGroup/CreateStudyTests.java
@@ -1,0 +1,104 @@
+package com.example.study_monster_back.studyGroup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.study_monster_back.group.dto.StudyGroupRequestDTO;
+import com.example.study_monster_back.group.repository.StudyGroupRepository;
+import com.example.study_monster_back.group.repository.StudyMemberRepository;
+import com.example.study_monster_back.group.service.StudyGroupServiceImpl;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.repository.UserRepository;
+
+public class CreateStudyTests {
+
+    private StudyGroupRepository studyGroupRepository;
+    private UserRepository userRepository;
+    private StudyMemberRepository studyMemberRepository;
+    private StudyGroupServiceImpl studyGroupService;
+
+    @BeforeEach
+    void setUp() {
+        studyGroupRepository = mock(StudyGroupRepository.class);
+        userRepository = mock(UserRepository.class);
+        studyMemberRepository = mock(StudyMemberRepository.class);
+        studyGroupService = new StudyGroupServiceImpl(
+                studyGroupRepository, userRepository, studyMemberRepository
+        );
+    }
+
+    @Test
+    void 모집인원은2명이상() {
+        // given
+        StudyGroupRequestDTO dto = new StudyGroupRequestDTO();
+        dto.setName("스터디");
+        dto.setDescription("설명");
+        dto.setLimit_members(1); // 
+        dto.setDeadline(LocalDateTime.now().plusDays(3));
+
+        User mockUser = new User();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        // when & then
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> studyGroupService.create(dto, 1L));
+        assertEquals("모집 인원은 2명 이상이어야 합니다.", ex.getMessage());
+    }
+
+    @Test
+    void 모집마감일이오늘이전일때() {
+        StudyGroupRequestDTO dto = new StudyGroupRequestDTO();
+        dto.setName("스터디");
+        dto.setDescription("설명");
+        dto.setLimit_members(3);
+        dto.setDeadline(LocalDateTime.now().minusDays(1)); 
+
+        User mockUser = new User();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> studyGroupService.create(dto, 1L));
+        assertEquals("모집 마감일은 현재 시각 이후여야 합니다.", ex.getMessage());
+    }
+
+    @Test
+    void 스터디이름공백() {
+        StudyGroupRequestDTO dto = new StudyGroupRequestDTO();
+        dto.setName("  "); // 공백만
+        dto.setDescription("설명");
+        dto.setLimit_members(3);
+        dto.setDeadline(LocalDateTime.now().plusDays(2));
+
+        User mockUser = new User();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> studyGroupService.create(dto, 1L));
+        assertEquals("스터디 제목을 입력해 주세요.", ex.getMessage());
+    }
+
+    @Test
+    void 설명공백일때() {
+        StudyGroupRequestDTO dto = new StudyGroupRequestDTO();
+        dto.setName("스터디");
+        dto.setDescription(" "); // 
+        dto.setLimit_members(3);
+        dto.setDeadline(LocalDateTime.now().plusDays(2));
+
+        User mockUser = new User();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> studyGroupService.create(dto, 1L));
+        assertEquals("스터디 설명을 입력해 주세요.", ex.getMessage());
+    }
+    
+}


### PR DESCRIPTION
## 작업 내용
- 스터디 그룹 생성 페이지에서 정보를 받아오는 것을 구현했습니다.
- DB와 데이터 update를 위해 스케줄러를 이용하여 하루에 한번 갱신되도록 구현했습니다. (status)
- 서비스 구현체에 함수를 작성하면서 예외처리를 같이 작성했습니다. 


## 연관된 이슈
- #16

## 스크린샷 (선택)
- ![image](https://github.com/user-attachments/assets/a54d4437-46ab-43bb-8b93-84625867c40a)

## 특이사항(선택)
> 이전 작업하던 내용과 연관되는 파일이 많아서 feat/#7 브랜치에 새로운 브랜치를 생성하여 작업했습니다.
> 로그인, 태그 구현이 필요합니다.
> 추후 예외처리가 추가될 확률이 높습니다. 
> 예외처리를 따로 빼는 것을 고민했는데 일단은 그러지 않았습니다. 의견 부탁드립니다.
