### PR TITLE
게시글 수정 및 삭제

### DIFF
--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -34,4 +34,12 @@ public class BoardController {
         CreateBoardResponseDto boardResponseDto = boardService.createBoard(boardRequestDto);
         return ResponseEntity.ok(boardResponseDto);
     }
+
+    @DeleteMapping("/{boardId}")
+    @Operation(summary = "게시글 삭제", description = "게시글을 삭제하면서 게시글과 연관된 댓글, 좋아요, 피드백, 게시글 태그를 함께 삭제합니다.")
+    public ResponseEntity<String> deleteBoard(@PathVariable Long boardId) {
+        // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져와서 자신의 게시글일 경우에만 삭제
+        boardService.deleteBoard(boardId);
+        return ResponseEntity.ok("게시글을 정상적으로 삭제했습니다.");
+    }
 }

--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -6,12 +6,15 @@ import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.UpdateBoardResponseDto;
 import com.example.study_monster_back.board.service.BoardService;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @CrossOrigin
 @RequiredArgsConstructor
@@ -51,5 +54,12 @@ public class BoardController {
         // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져와서 자신의 게시글일 경우에만 삭제
         boardService.deleteBoard(boardId);
         return ResponseEntity.ok("게시글을 정상적으로 삭제했습니다.");
+    }
+
+    @GetMapping("/{boardId}/tags")
+    @Operation(summary = "게시글의 태그 조회", description = "해당 게시글의 태그를 조회합니다.")
+    public ResponseEntity<List<TagResponseDto>> getBoardTags(@PathVariable Long boardId) {
+        List<TagResponseDto> tagResponseDtoList = boardService.getBoardTags(boardId);
+        return ResponseEntity.ok(tagResponseDtoList);
     }
 }

--- a/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
+++ b/src/main/java/com/example/study_monster_back/board/controller/BoardController.java
@@ -1,8 +1,10 @@
 package com.example.study_monster_back.board.controller;
 
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.request.UpdateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
+import com.example.study_monster_back.board.dto.response.UpdateBoardResponseDto;
 import com.example.study_monster_back.board.service.BoardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,6 +35,14 @@ public class BoardController {
         // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져올 예정
         CreateBoardResponseDto boardResponseDto = boardService.createBoard(boardRequestDto);
         return ResponseEntity.ok(boardResponseDto);
+    }
+
+    @PutMapping("/{boardId}")
+    @Operation(summary = "게시글 수정", description = "게시글과 게시글 태그를 수정합니다.")
+    public ResponseEntity<UpdateBoardResponseDto> updateBoard(@PathVariable Long boardId, @Valid @RequestBody UpdateBoardRequestDto boardRequestDto) {
+        // TODO: 추후에 @AuthenticationPrincipal로 유저 정보 가져와서 자신의 게시글인 경우에만 수정
+        UpdateBoardResponseDto updateBoardResponseDto = boardService.updateBoard(boardId,boardRequestDto);
+        return ResponseEntity.ok(updateBoardResponseDto);
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/example/study_monster_back/board/dto/request/UpdateBoardRequestDto.java
+++ b/src/main/java/com/example/study_monster_back/board/dto/request/UpdateBoardRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.study_monster_back.board.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateBoardRequestDto {
+
+    @NotBlank(message = "제목은 필수입니다")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다")
+    private String content;
+
+    private Long userId;
+
+    private List<String> tags;
+}

--- a/src/main/java/com/example/study_monster_back/board/dto/response/UpdateBoardResponseDto.java
+++ b/src/main/java/com/example/study_monster_back/board/dto/response/UpdateBoardResponseDto.java
@@ -1,0 +1,41 @@
+package com.example.study_monster_back.board.dto.response;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
+import com.example.study_monster_back.user.dto.response.UserSummaryResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateBoardResponseDto {
+
+    private Long id;
+    private String title;
+    private String content;
+    private UserSummaryResponseDto user;
+    private List<TagResponseDto> tags;
+    private LocalDateTime created_at;
+    private LocalDateTime updated_at;
+
+    public static UpdateBoardResponseDto from(Board board) {
+        return UpdateBoardResponseDto.builder()
+                .id(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .user(UserSummaryResponseDto.from(board.getUser()))
+                .tags(board.getBoardTags().stream()
+                        .map(boardTag -> TagResponseDto.from(boardTag.getTag()))
+                        .toList())
+                .created_at(board.getCreated_at())
+                .updated_at(board.getUpdated_at())
+                .build();
+    }
+}

--- a/src/main/java/com/example/study_monster_back/board/entity/Board.java
+++ b/src/main/java/com/example/study_monster_back/board/entity/Board.java
@@ -1,5 +1,6 @@
 package com.example.study_monster_back.board.entity;
 
+import com.example.study_monster_back.board.dto.request.UpdateBoardRequestDto;
 import com.example.study_monster_back.tag.entity.BoardTag;
 import com.example.study_monster_back.user.entity.User;
 import jakarta.persistence.*;
@@ -44,6 +45,16 @@ public class Board {
 
     public void addBoardTag(BoardTag boardTag) {
         boardTags.add(boardTag);
+    }
+
+    public void removeBoardTag(BoardTag boardTag) {
+        boardTags.remove(boardTag);
+        boardTag.setBoard(null);
+    }
+
+    public void updateBoardTitleAndContent(UpdateBoardRequestDto boardRequestDto) {
+        this.title = boardRequestDto.getTitle();
+        this.content = boardRequestDto.getContent();
     }
 
 }

--- a/src/main/java/com/example/study_monster_back/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/study_monster_back/board/repository/BoardRepository.java
@@ -5,9 +5,11 @@ import com.example.study_monster_back.board.entity.Board;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("""
     SELECT b board, u writer

--- a/src/main/java/com/example/study_monster_back/board/service/BoardService.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardService.java
@@ -1,14 +1,18 @@
 package com.example.study_monster_back.board.service;
 
+import com.example.study_monster_back.board.dto.request.UpdateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
+import com.example.study_monster_back.board.dto.response.UpdateBoardResponseDto;
 
 public interface BoardService {
 
     GetBoardResponseDto getBoard(Long boardId);
 
     CreateBoardResponseDto createBoard(CreateBoardRequestDto boardRequestDto);
+
+    UpdateBoardResponseDto updateBoard(Long boardId, UpdateBoardRequestDto boardRequestDto);
 
     void deleteBoard(Long boardId);
 }

--- a/src/main/java/com/example/study_monster_back/board/service/BoardService.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardService.java
@@ -5,6 +5,9 @@ import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.UpdateBoardResponseDto;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
+
+import java.util.List;
 
 public interface BoardService {
 
@@ -15,4 +18,6 @@ public interface BoardService {
     UpdateBoardResponseDto updateBoard(Long boardId, UpdateBoardRequestDto boardRequestDto);
 
     void deleteBoard(Long boardId);
+
+    List<TagResponseDto> getBoardTags(Long boardId);
 }

--- a/src/main/java/com/example/study_monster_back/board/service/BoardService.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardService.java
@@ -1,12 +1,14 @@
 package com.example.study_monster_back.board.service;
 
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
-
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
-import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
 
 public interface BoardService {
+
     GetBoardResponseDto getBoard(Long boardId);
+
     CreateBoardResponseDto createBoard(CreateBoardRequestDto boardRequestDto);
+
+    void deleteBoard(Long boardId);
 }

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -5,6 +5,10 @@ import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
 import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.board.repository.BoardRepository;
+import com.example.study_monster_back.comment.repository.CommentRepository;
+import com.example.study_monster_back.feedback.repository.FeedbackRepository;
+import com.example.study_monster_back.like.entity.Like;
+import com.example.study_monster_back.like.repository.LikeRepository;
 import com.example.study_monster_back.tag.entity.BoardTag;
 import com.example.study_monster_back.tag.entity.Tag;
 import com.example.study_monster_back.tag.service.BoardTagService;
@@ -19,8 +23,12 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class BoardServiceImpl implements BoardService {
+
     private final BoardRepository boardRepository;
     private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+    private final LikeRepository likeRepository;
+    private final FeedbackRepository feedbackRepository;
     private final TagService tagService;
     private final BoardTagService boardTagService;
     private final TagValidator tagValidator;
@@ -37,8 +45,7 @@ public class BoardServiceImpl implements BoardService {
     public CreateBoardResponseDto createBoard(CreateBoardRequestDto boardRequestDto) {
 
         // TODO: 추후 수정 예정(지금은 유저 정보를 dto에서 받아옴.)
-        User user = userRepository.findById(boardRequestDto.getUserId())
-            .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + boardRequestDto.getUserId()));
+        User user = getUserOrThrow(boardRequestDto.getUserId());
 
         Board board = Board.builder()
             .title(boardRequestDto.getTitle())
@@ -54,5 +61,26 @@ public class BoardServiceImpl implements BoardService {
         }
 
         return CreateBoardResponseDto.from(board);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBoard(Long boardId) {
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found with ID: " + boardId));
+        // TODO: userId 시큐리티컨텍스트에서 받아서 자신의 게시글이 맞는지 확인해야 함.
+
+        commentRepository.deleteAllByBoard(board);
+        likeRepository.deleteAllByBoard(board);
+        feedbackRepository.deleteAllByBoard(board);
+        boardRepository.delete(board);
+    }
+
+    private User getUserOrThrow(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found with ID: " + userId));
+        return user;
     }
 }

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -9,8 +9,8 @@ import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.board.repository.BoardRepository;
 import com.example.study_monster_back.comment.repository.CommentRepository;
 import com.example.study_monster_back.feedback.repository.FeedbackRepository;
-import com.example.study_monster_back.like.entity.Like;
 import com.example.study_monster_back.like.repository.LikeRepository;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
 import com.example.study_monster_back.tag.entity.BoardTag;
 import com.example.study_monster_back.tag.entity.Tag;
 import com.example.study_monster_back.tag.service.BoardTagService;
@@ -18,11 +18,13 @@ import com.example.study_monster_back.tag.service.TagService;
 import com.example.study_monster_back.tag.util.TagValidator;
 import com.example.study_monster_back.user.entity.User;
 import com.example.study_monster_back.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -119,6 +121,20 @@ public class BoardServiceImpl implements BoardService {
         likeRepository.deleteAllByBoard(board);
         feedbackRepository.deleteAllByBoard(board);
         boardRepository.delete(board);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TagResponseDto> getBoardTags(Long boardId) {
+
+        Board board = boardRepository.findByIdWithTags(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found with ID: " + boardId));
+
+        List<TagResponseDto> tagResponseDtoList = board.getBoardTags().stream()
+                .map(bt -> TagResponseDto.from(bt.getTag()))
+                .collect(Collectors.toList());
+
+        return tagResponseDtoList;
     }
 
     private User getUserOrThrow(Long userId) {

--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -1,8 +1,10 @@
 package com.example.study_monster_back.board.service;
 
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.request.UpdateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.dto.response.GetBoardResponseDto;
+import com.example.study_monster_back.board.dto.response.UpdateBoardResponseDto;
 import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.board.repository.BoardRepository;
 import com.example.study_monster_back.comment.repository.CommentRepository;
@@ -19,6 +21,10 @@ import com.example.study_monster_back.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -61,6 +67,44 @@ public class BoardServiceImpl implements BoardService {
         }
 
         return CreateBoardResponseDto.from(board);
+    }
+
+    @Override
+    @Transactional
+    public UpdateBoardResponseDto updateBoard(Long boardId, UpdateBoardRequestDto boardRequestDto) {
+
+        // TODO: userId 시큐리티컨텍스트에서 받아서 자신의 게시글이 맞는지 확인해야 함.
+        Board board = boardRepository.findByIdWithTags(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("Board not found with ID: " + boardId));
+
+        User user = getUserOrThrow(boardRequestDto.getUserId());
+        if(!board.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("게시글을 작성한 사용자만 게시글을 수정할 수 있습니다.");
+        }
+
+        board.updateBoardTitleAndContent(boardRequestDto);
+
+        Set<String> updateTagNames =  tagValidator.filterValidTags(boardRequestDto.getTags());
+        Set<String> existingTagNames = board.getBoardTags().stream()
+                .map(bt -> bt.getTag().getName())
+                .collect(Collectors.toSet());
+
+        for (BoardTag boardTag : new ArrayList<>(board.getBoardTags())) {
+            if (!updateTagNames.contains(boardTag.getTag().getName())) {
+                board.removeBoardTag(boardTag);
+            }
+        }
+
+        for (String tagName : updateTagNames) {
+            if (!existingTagNames.contains(tagName)) {
+                Tag tag = tagService.findOrCreateTag(tagName);
+                BoardTag boardTag = boardTagService.createBoardTag(board, tag);
+                board.addBoardTag(boardTag);
+            }
+        }
+
+        return UpdateBoardResponseDto.from(board);
+
     }
 
     @Override

--- a/src/main/java/com/example/study_monster_back/comment/entity/Comment.java
+++ b/src/main/java/com/example/study_monster_back/comment/entity/Comment.java
@@ -2,6 +2,8 @@ package com.example.study_monster_back.comment.entity;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -16,6 +18,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.Data;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Data
 public class Comment{

--- a/src/main/java/com/example/study_monster_back/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/study_monster_back/comment/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package com.example.study_monster_back.comment.repository;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    void deleteAllByBoard(Board board);
+}

--- a/src/main/java/com/example/study_monster_back/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/study_monster_back/comment/repository/CommentRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     void deleteAllByBoard(Board board);
+    Long countByBoard(Board board);
 }

--- a/src/main/java/com/example/study_monster_back/feedback/entity/Feedback.java
+++ b/src/main/java/com/example/study_monster_back/feedback/entity/Feedback.java
@@ -2,6 +2,8 @@ package com.example.study_monster_back.feedback.entity;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 import com.example.study_monster_back.board.entity.Board;
@@ -14,6 +16,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import lombok.Data;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Data
 public class Feedback{

--- a/src/main/java/com/example/study_monster_back/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/study_monster_back/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,11 @@
+package com.example.study_monster_back.feedback.repository;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+    void deleteAllByBoard(Board board);
+}

--- a/src/main/java/com/example/study_monster_back/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/example/study_monster_back/feedback/repository/FeedbackRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     void deleteAllByBoard(Board board);
+    Long countByBoard(Board board);
 }

--- a/src/main/java/com/example/study_monster_back/like/entity/Like.java
+++ b/src/main/java/com/example/study_monster_back/like/entity/Like.java
@@ -9,8 +9,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity
 @Data
 public class Like{

--- a/src/main/java/com/example/study_monster_back/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/study_monster_back/like/repository/LikeRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
     void deleteAllByBoard(Board board);
+    Long countByBoard(Board board);
 }

--- a/src/main/java/com/example/study_monster_back/like/repository/LikeRepository.java
+++ b/src/main/java/com/example/study_monster_back/like/repository/LikeRepository.java
@@ -1,0 +1,11 @@
+package com.example.study_monster_back.like.repository;
+
+import com.example.study_monster_back.board.entity.Board;
+import com.example.study_monster_back.like.entity.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    void deleteAllByBoard(Board board);
+}

--- a/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
@@ -2,6 +2,8 @@ package com.example.study_monster_back.tag.repository;
 
 import com.example.study_monster_back.tag.entity.BoardTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
 }

--- a/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/BoardTagRepository.java
@@ -1,9 +1,11 @@
 package com.example.study_monster_back.tag.repository;
 
+import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.tag.entity.BoardTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
+    Long countByBoard(Board board);
 }

--- a/src/main/java/com/example/study_monster_back/tag/repository/TagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/TagRepository.java
@@ -2,10 +2,11 @@ package com.example.study_monster_back.tag.repository;
 
 import com.example.study_monster_back.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
-
     Optional<Tag> findByName(String name);
 }

--- a/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
+++ b/src/main/java/com/example/study_monster_back/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.example.study_monster_back.user.repository;
 
 import com.example.study_monster_back.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 }

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
@@ -11,6 +11,7 @@ import com.example.study_monster_back.feedback.entity.Feedback;
 import com.example.study_monster_back.feedback.repository.FeedbackRepository;
 import com.example.study_monster_back.like.entity.Like;
 import com.example.study_monster_back.like.repository.LikeRepository;
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
 import com.example.study_monster_back.tag.repository.BoardTagRepository;
 import com.example.study_monster_back.user.entity.User;
 import com.example.study_monster_back.user.repository.UserRepository;
@@ -139,7 +140,7 @@ public class BoardServiceTest {
 
 
     @Test
-    void 게시글_삭제_시_연관된_데이터도_함께_삭제됨() {
+    void 게시글_삭제_시_연관된_데이터도_함께_삭제된다() {
         // given
         User user = createAndSaveUser();
 
@@ -174,6 +175,33 @@ public class BoardServiceTest {
         assertThat(commentRepository.countByBoard(board)).isEqualTo(0);
         assertThat(likeRepository.countByBoard(board)).isEqualTo(0);
         assertThat(feedbackRepository.countByBoard(board)).isEqualTo(0);
+    }
+
+    @Test
+    void 게시글Id로_해당_게시글의_태그를_조회한다() {
+        // given
+        User user = createAndSaveUser();
+
+        CreateBoardRequestDto requestDto = new CreateBoardRequestDto(
+                "해당 게시글의 태그 조회",
+                "해당 게시글의 태그 조회",
+                user.getId(),
+                Arrays.asList("get_tag1", "get_tag2")
+        );
+        CreateBoardResponseDto created = boardService.createBoard(requestDto);
+
+
+        // when
+        List<TagResponseDto> tagResponseDtoList = boardService.getBoardTags(created.getId());
+
+        // then
+        List<String> tagNames = tagResponseDtoList.stream()
+                .map(tagResponseDto -> tagResponseDto.getName())
+                .toList();
+
+        assertThat(tagNames.size()).isEqualTo(2);
+        assertTrue(tagNames.contains("get_tag1"));
+        assertTrue(tagNames.contains("get_tag2"));
     }
 
 

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
@@ -1,10 +1,17 @@
 package com.example.study_monster_back.board.service;
 
 import com.example.study_monster_back.board.dto.request.CreateBoardRequestDto;
+import com.example.study_monster_back.board.dto.request.UpdateBoardRequestDto;
 import com.example.study_monster_back.board.dto.response.CreateBoardResponseDto;
 import com.example.study_monster_back.board.entity.Board;
 import com.example.study_monster_back.board.repository.BoardRepository;
-import com.example.study_monster_back.tag.repository.TagRepository;
+import com.example.study_monster_back.comment.entity.Comment;
+import com.example.study_monster_back.comment.repository.CommentRepository;
+import com.example.study_monster_back.feedback.entity.Feedback;
+import com.example.study_monster_back.feedback.repository.FeedbackRepository;
+import com.example.study_monster_back.like.entity.Like;
+import com.example.study_monster_back.like.repository.LikeRepository;
+import com.example.study_monster_back.tag.repository.BoardTagRepository;
 import com.example.study_monster_back.user.entity.User;
 import com.example.study_monster_back.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -13,10 +20,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -34,7 +43,16 @@ public class BoardServiceTest {
     private UserRepository userRepository;
 
     @Autowired
-    private TagRepository tagRepository;
+    private BoardTagRepository boardTagRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private FeedbackRepository feedbackRepository;
+
+    @Autowired
+    private LikeRepository likeRepository;
 
     @Test
     void 게시글_생성_요청시_게시글과_태그가_함께_저장된다() {
@@ -79,6 +97,86 @@ public class BoardServiceTest {
     }
 
 
+    @Test
+    void 게시글_수정_시_제목_내용_태그가_정상적으로_변경된다() {
+        // given
+        User user = createAndSaveUser();
+
+        CreateBoardRequestDto createDto = new CreateBoardRequestDto(
+                "원래 제목",
+                "원래 내용",
+                user.getId(),
+                Arrays.asList("original1", "original2")
+        );
+        CreateBoardResponseDto createdBoard = boardService.createBoard(createDto);
+
+        UpdateBoardRequestDto updateDto = new UpdateBoardRequestDto(
+                "수정된 제목",
+                "수정된 내용",
+                user.getId(),
+                Arrays.asList("original1", "change1") // original2 → 제거, change1 → 추가
+        );
+
+        // when
+        boardService.updateBoard(createdBoard.getId(), updateDto);
+
+        // then
+        Board updatedBoard = boardRepository.findByIdWithTags(createdBoard.getId())
+                .orElseThrow(() -> new AssertionError("게시글이 수정되지 않았습니다."));
+
+        assertThat(updatedBoard.getTitle()).isEqualTo("수정된 제목");
+        assertThat(updatedBoard.getContent()).isEqualTo("수정된 내용");
+
+        List<String> tagNames = updatedBoard.getBoardTags().stream()
+                .map(bt -> bt.getTag().getName())
+                .toList();
+
+        assertThat(tagNames.size()).isEqualTo(2);
+        assertTrue(tagNames.contains("original1"));
+        assertTrue(tagNames.contains("change1"));
+        assertFalse(tagNames.contains("original2"));
+    }
+
+
+    @Test
+    void 게시글_삭제_시_연관된_데이터도_함께_삭제됨() {
+        // given
+        User user = createAndSaveUser();
+
+        CreateBoardRequestDto requestDto = new CreateBoardRequestDto(
+                "삭제 테스트 제목",
+                "삭제 테스트 내용",
+                user.getId(),
+                Arrays.asList("deleteTest1", "deleteTest2")
+        );
+        CreateBoardResponseDto created = boardService.createBoard(requestDto);
+        Long boardId = created.getId();
+
+        Board board = boardRepository.findById(boardId).orElseThrow();
+
+        commentRepository.save(new Comment(null, "댓글1", LocalDateTime.now(), LocalDateTime.now(), user, board));
+        commentRepository.save(new Comment(null, "댓글2", LocalDateTime.now(), LocalDateTime.now(), user, board));
+        likeRepository.save(new Like(null, user, board));
+        feedbackRepository.save(new Feedback(null, "피드백1", LocalDateTime.now(), board));
+
+        assertThat(boardRepository.findById(boardId)).isNotEmpty();
+        assertThat(boardTagRepository.countByBoard(board)).isEqualTo(2);
+        assertThat(commentRepository.countByBoard(board)).isEqualTo(2);
+        assertThat(likeRepository.countByBoard(board)).isEqualTo(1);
+        assertThat(feedbackRepository.countByBoard(board)).isEqualTo(1);
+
+        // when
+        boardService.deleteBoard(boardId);
+
+        // then
+        assertThat(boardRepository.findById(boardId)).isEmpty();
+        assertThat(boardTagRepository.countByBoard(board)).isEqualTo(0);
+        assertThat(commentRepository.countByBoard(board)).isEqualTo(0);
+        assertThat(likeRepository.countByBoard(board)).isEqualTo(0);
+        assertThat(feedbackRepository.countByBoard(board)).isEqualTo(0);
+    }
+
+
     private User createAndSaveUser() {
 
         User user = new User();
@@ -91,4 +189,5 @@ public class BoardServiceTest {
 
         return userRepository.save(user);
     }
+
 }

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceTest.java
@@ -158,7 +158,7 @@ public class BoardServiceTest {
         commentRepository.save(new Comment(null, "댓글1", LocalDateTime.now(), LocalDateTime.now(), user, board));
         commentRepository.save(new Comment(null, "댓글2", LocalDateTime.now(), LocalDateTime.now(), user, board));
         likeRepository.save(new Like(null, user, board));
-        feedbackRepository.save(new Feedback(null, "피드백1", LocalDateTime.now(), board));
+        feedbackRepository.save(new Feedback(null, "피드백1", "피드백2", LocalDateTime.now(), board));
 
         assertThat(boardRepository.findById(boardId)).isNotEmpty();
         assertThat(boardTagRepository.countByBoard(board)).isEqualTo(2);


### PR DESCRIPTION
## 작업 내용
- 게시글 수정 기능
  - 태그 수정 시 새로운 태그가 생기면 새로운 BoardTag 만듦.
  - 원래 있었던 태그가 없어졌다면 기존의 BoardTag 삭제.
- 게시글 삭제 기능
  - 게시글과 연관 있는 좋아요, 댓글, 피드백, 게시글 태그 함께 삭제.
 - 해당 게시글의 태그 조회 기능

## 연관된 이슈
- #22

## 스크린샷 (선택)
<img width="477" alt="image" src="https://github.com/user-attachments/assets/8a64d300-7bd0-4086-861b-25bb6da07089" />

## 특이사항(선택)
- 게시글 수정 및 삭제할 때 자신의 쓴 게시글인지 확인하는 부분 추후에 구현 예정
