### PR TITLE
게시글 수정 후 피드백 생성 시 기존 피드백 제거

### DIFF
--- a/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/board/service/BoardServiceImpl.java
@@ -17,9 +17,9 @@ import com.example.study_monster_back.tag.service.TagService;
 import com.example.study_monster_back.tag.util.TagValidator;
 import com.example.study_monster_back.user.entity.User;
 import com.example.study_monster_back.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -66,12 +66,14 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
+    @Transactional
     public StudyFeedbackResponse getStudyFeedback(Long boardId) {
         Board board = boardRepository.findById(boardId).orElseThrow(() ->
             new RuntimeException("해당 id를 가진 게시글이 없습니다.")
         );
         Optional<Feedback> optionalFeedback = feedbackRepository.findByBoard(board);
         if (optionalFeedback.isEmpty() || optionalFeedback.get().getCreated_at().isBefore(board.getUpdated_at())) {
+            optionalFeedback.ifPresent(feedback -> feedbackRepository.deleteById(feedback.getId()));
             OpenAiStudyFeedbackResponse studyFeedback = openAiService.getStudyFeedback(board.getTitle(), board.getContent());
             Feedback feedback = feedbackRepository.save(
                 Feedback.builder()

--- a/src/test/java/com/example/study_monster_back/board/service/BoardServiceImplTest.java
+++ b/src/test/java/com/example/study_monster_back/board/service/BoardServiceImplTest.java
@@ -169,6 +169,8 @@ class BoardServiceImplTest {
         StudyFeedbackResponse response = boardServiceImpl.getStudyFeedback(board.getId());
 
         // then
+        Feedback feedback = feedbackRepository.findByBoard(board).get();
+        assertThat(feedback).isNotNull();
         assertThat(response.getFeedback()).isNull();
         assertThat(response.getFutureLearningStrategy()).isNull();
         verify(openAiService, times(1)).getStudyFeedback(anyString(), anyString());


### PR DESCRIPTION
## 작업 내용
- 게시글 수정 후 피드백 생성 시 기존 피드백을 제거하고 새로 생성하도록 변경했습니다.
- 기존의 테스트코드가 피드백이 중복으로 생기는 것을 확인할 수 없어 테스트코드를 수정했습니다.

## 연관된 이슈
- #29 