### PR TITLE
스터디 그룹 생성 시 태그도 함께 저장

### DIFF
--- a/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
@@ -1,6 +1,5 @@
 package com.example.study_monster_back.group.controller;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -22,18 +21,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @CrossOrigin(origins = "http://localhost:5173")
 @RestController
-@RequestMapping("/study-group")
+@RequestMapping("/study-groups")
 @RequiredArgsConstructor
 public class StudyGroupController {
 
     private final StudyGroupService studyGroupService;
 
-    @GetMapping("/")
+    @GetMapping()
     public ResponseEntity<List<StudyGroupResponseDTO>> getList() {
         List<StudyGroupResponseDTO> studyGroups = studyGroupService.getAllStudyGroups();
         return ResponseEntity.ok(studyGroups);
     }
-    @PostMapping("/create")
+
+    @PostMapping()
     public ResponseEntity<?> createStudyGroup(
         @RequestBody StudyGroupRequestDTO dto,
         @RequestParam Long userId) { //아이디는 테스트용

--- a/src/main/java/com/example/study_monster_back/group/dto/StudyGroupRequestDTO.java
+++ b/src/main/java/com/example/study_monster_back/group/dto/StudyGroupRequestDTO.java
@@ -1,6 +1,7 @@
 package com.example.study_monster_back.group.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.Data;
 
@@ -12,6 +13,6 @@ public class StudyGroupRequestDTO {
     private Integer limit_members;
     private LocalDateTime deadline;
     private String nickname;
-    //todo 태그 추후 추가
+    private List<String> tags;
     
 }

--- a/src/main/java/com/example/study_monster_back/group/dto/StudyGroupResponseDTO.java
+++ b/src/main/java/com/example/study_monster_back/group/dto/StudyGroupResponseDTO.java
@@ -3,6 +3,7 @@ package com.example.study_monster_back.group.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.example.study_monster_back.tag.dto.response.TagResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,7 @@ public class StudyGroupResponseDTO {
 
     private Long id;
     private String name;
-    private List<String> tagList;
+    private List<TagResponseDto> tagList;
     private LocalDateTime created_at;
     private String description;
     private Integer limit_members;

--- a/src/main/java/com/example/study_monster_back/group/entity/StudyGroup.java
+++ b/src/main/java/com/example/study_monster_back/group/entity/StudyGroup.java
@@ -1,16 +1,15 @@
 package com.example.study_monster_back.group.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.study_monster_back.tag.entity.StudyGroupTag;
+import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.example.study_monster_back.user.entity.User;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import lombok.Data;
 
 @Entity
@@ -30,4 +29,11 @@ public class StudyGroup{
 
     @ManyToOne
     private User creator;
+
+    @OneToMany(mappedBy = "studyGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyGroupTag> studyGroupTags = new ArrayList<>();
+
+    public void addStudyGroupTag(StudyGroupTag studyGroupTag){
+        studyGroupTags.add(studyGroupTag);
+    }
 }

--- a/src/main/java/com/example/study_monster_back/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/example/study_monster_back/group/repository/StudyGroupRepository.java
@@ -2,9 +2,13 @@ package com.example.study_monster_back.group.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.example.study_monster_back.group.entity.StudyGroup;
@@ -17,6 +21,14 @@ public interface StudyGroupRepository extends JpaRepository<StudyGroup, Long> {
 
     List<StudyGroup> findByDeadlineBeforeAndStatus(LocalDateTime now, String string);
 
-    
+    @Query("SELECT sg FROM StudyGroup sg LEFT JOIN FETCH sg.studyGroupTags sgt LEFT JOIN FETCH sgt.tag WHERE sg.id = :id")
+    Optional<StudyGroup> findByIdWithTags(@Param("id") Long id);
+
+    @Query("SELECT DISTINCT sg FROM StudyGroup sg LEFT JOIN FETCH sg.studyGroupTags sgt LEFT JOIN FETCH sgt.tag")
+    List<StudyGroup> findAllWithTags();
+
+    @Query(value = "SELECT DISTINCT sg FROM StudyGroup sg LEFT JOIN FETCH sg.studyGroupTags sgt LEFT JOIN FETCH sgt.tag",
+            countQuery = "SELECT COUNT(DISTINCT sg) FROM StudyGroup sg")
+    Page<StudyGroup> findAllWithTags(Pageable pageable);
     
 }

--- a/src/main/java/com/example/study_monster_back/tag/entity/StudyGroupTag.java
+++ b/src/main/java/com/example/study_monster_back/tag/entity/StudyGroupTag.java
@@ -2,13 +2,16 @@ package com.example.study_monster_back.tag.entity;
 
 import com.example.study_monster_back.group.entity.StudyGroup;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Data
 public class StudyGroupTag{
@@ -16,8 +19,10 @@ public class StudyGroupTag{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JsonIgnore
     private StudyGroup studyGroup;
 }

--- a/src/main/java/com/example/study_monster_back/tag/repository/StudyGroupTagRepository.java
+++ b/src/main/java/com/example/study_monster_back/tag/repository/StudyGroupTagRepository.java
@@ -1,0 +1,9 @@
+package com.example.study_monster_back.tag.repository;
+
+import com.example.study_monster_back.tag.entity.StudyGroupTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyGroupTagRepository extends JpaRepository<StudyGroupTag, Long> {
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/StudyGroupTagService.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/StudyGroupTagService.java
@@ -1,0 +1,10 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.tag.entity.StudyGroupTag;
+import com.example.study_monster_back.tag.entity.Tag;
+
+public interface StudyGroupTagService {
+
+    StudyGroupTag createStudyGroupTag(StudyGroup studyGroup, Tag tag);
+}

--- a/src/main/java/com/example/study_monster_back/tag/service/StudyGroupTagServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/tag/service/StudyGroupTagServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.study_monster_back.tag.service;
+
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.tag.entity.StudyGroupTag;
+import com.example.study_monster_back.tag.entity.Tag;
+import com.example.study_monster_back.tag.repository.StudyGroupTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class StudyGroupTagServiceImpl implements StudyGroupTagService {
+
+    private final StudyGroupTagRepository studyGroupTagRepository;
+
+    @Override
+    public StudyGroupTag createStudyGroupTag(StudyGroup studyGroup, Tag tag) {
+        StudyGroupTag studyGroupTag = StudyGroupTag.builder()
+                .studyGroup(studyGroup)
+                .tag(tag)
+                .build();
+        return studyGroupTagRepository.save(studyGroupTag);
+    }
+}

--- a/src/test/java/com/example/study_monster_back/studyGroup/CreateStudyTests.java
+++ b/src/test/java/com/example/study_monster_back/studyGroup/CreateStudyTests.java
@@ -8,6 +8,13 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import com.example.study_monster_back.tag.repository.StudyGroupTagRepository;
+import com.example.study_monster_back.tag.repository.TagRepository;
+import com.example.study_monster_back.tag.service.StudyGroupTagService;
+import com.example.study_monster_back.tag.service.StudyGroupTagServiceImpl;
+import com.example.study_monster_back.tag.service.TagService;
+import com.example.study_monster_back.tag.service.TagServiceImpl;
+import com.example.study_monster_back.tag.util.TagValidator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +31,26 @@ public class CreateStudyTests {
     private UserRepository userRepository;
     private StudyMemberRepository studyMemberRepository;
     private StudyGroupServiceImpl studyGroupService;
+    private TagService tagService;
+    private StudyGroupTagService studyGroupTagService;
+    private TagValidator tagValidator;
+    private TagRepository tagRepository;
+    private StudyGroupTagRepository studyGroupTagRepository;
+
 
     @BeforeEach
     void setUp() {
         studyGroupRepository = mock(StudyGroupRepository.class);
         userRepository = mock(UserRepository.class);
         studyMemberRepository = mock(StudyMemberRepository.class);
+        tagRepository = mock(TagRepository.class);
+        tagService = new TagServiceImpl(tagRepository);
+        studyGroupTagRepository = mock(StudyGroupTagRepository.class);
+        studyGroupTagService = new StudyGroupTagServiceImpl(studyGroupTagRepository);
+        tagValidator = new TagValidator();
         studyGroupService = new StudyGroupServiceImpl(
-                studyGroupRepository, userRepository, studyMemberRepository
+                studyGroupRepository, userRepository, studyMemberRepository,
+                tagService, studyGroupTagService, tagValidator
         );
     }
 


### PR DESCRIPTION
## 작업 내용
- 스터디 그룹 생성 시 태그도 함께 저장하는 기능을 구현했습니다.

## 연관된 이슈
- #16 

## 스크린샷 (선택)
-  없음.

## 특이사항(선택)
- 지영님이 만드신 기능 위에서 작업해야 해서 지영님 브랜치에서 새로운 브랜치를 만들어 작업했습니다.
