### PR TITLE
스터디 그룹 참여 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-
 @CrossOrigin
 @RestController
 @RequestMapping("/study-groups")
@@ -33,5 +32,5 @@ public class StudyGroupController {
     public ResponseEntity<StudyGroupResponseDTO> getStudyGroupById(@PathVariable Long studyId) {
     return ResponseEntity.ok(studyGroupService.getById(studyId));
 }
-
+   
 }

--- a/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyGroupController.java
@@ -32,7 +32,7 @@ public class StudyGroupController {
         List<StudyGroupResponseDTO> studyGroups = studyGroupService.getAllStudyGroups();
         return ResponseEntity.ok(studyGroups);
     }
-    @PostMapping("/new")
+    @PostMapping()
     public ResponseEntity<?> createStudyGroup(
         @RequestBody StudyGroupRequestDTO dto,
         @RequestParam Long userId) { //아이디는 테스트용

--- a/src/main/java/com/example/study_monster_back/group/controller/StudyMemberController.java
+++ b/src/main/java/com/example/study_monster_back/group/controller/StudyMemberController.java
@@ -1,0 +1,43 @@
+package com.example.study_monster_back.group.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.study_monster_back.group.exception.StudyJoinException;
+import com.example.study_monster_back.group.service.StudyMemberService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@CrossOrigin
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/study-groups")
+@Slf4j
+public class StudyMemberController {
+
+    private final StudyMemberService studyMemberService;
+
+    @PostMapping("/{studyId}/join")
+    public ResponseEntity<String> joinStudy(
+        @PathVariable Long studyId, @RequestParam Long userId) {
+
+        try {
+            log.info("컨트롤러 - 스터디 신청 시작. studyId: {}, userId: {}", studyId, userId);
+            studyMemberService.join(studyId, userId);
+     
+            return ResponseEntity.ok("스터디 신청이 완료되었습니다!");
+        } catch (StudyJoinException e) {
+            log.warn("비즈니스 로직 예외 발생: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (Exception e) {
+            log.error("서버 내부 오류 발생", e);
+            return ResponseEntity.internalServerError().body("서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+            }
+        }
+}

--- a/src/main/java/com/example/study_monster_back/group/entity/StudyMember.java
+++ b/src/main/java/com/example/study_monster_back/group/entity/StudyMember.java
@@ -4,10 +4,12 @@ package com.example.study_monster_back.group.entity;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.example.study_monster_back.user.entity.User;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,6 +19,7 @@ import lombok.Data;
 
 @Entity
 @Data
+@EntityListeners(AuditingEntityListener.class)
 public class StudyMember{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/study_monster_back/group/exception/StudyJoinException.java
+++ b/src/main/java/com/example/study_monster_back/group/exception/StudyJoinException.java
@@ -1,0 +1,7 @@
+package com.example.study_monster_back.group.exception;
+
+public class StudyJoinException extends RuntimeException{
+     public StudyJoinException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/study_monster_back/group/repository/StudyMemberRepository.java
+++ b/src/main/java/com/example/study_monster_back/group/repository/StudyMemberRepository.java
@@ -4,10 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.study_monster_back.group.entity.StudyGroup;
 import com.example.study_monster_back.group.entity.StudyMember;
+import com.example.study_monster_back.user.entity.User;
 
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
 
     int countMembersByStudyGroup(StudyGroup group);
+
+    boolean existsByUserAndStudyGroup(User user, StudyGroup group);
 
 
 } 

--- a/src/main/java/com/example/study_monster_back/group/service/StudyMemberService.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyMemberService.java
@@ -1,0 +1,5 @@
+package com.example.study_monster_back.group.service;
+
+public interface StudyMemberService  {
+    void join(Long studyId, Long userId);
+} 

--- a/src/main/java/com/example/study_monster_back/group/service/StudyMemberServiceImpl.java
+++ b/src/main/java/com/example/study_monster_back/group/service/StudyMemberServiceImpl.java
@@ -1,0 +1,72 @@
+package com.example.study_monster_back.group.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.group.entity.StudyMember;
+import com.example.study_monster_back.group.exception.StudyJoinException;
+import com.example.study_monster_back.group.repository.StudyGroupRepository;
+import com.example.study_monster_back.group.repository.StudyMemberRepository;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudyMemberServiceImpl implements StudyMemberService {
+
+    private final StudyGroupRepository studyGroupRepository;
+    private final UserRepository userRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    @Override
+    @Transactional
+    public void join(Long studyId, Long userId) {
+        log.info("스터디 신청 요청 - studyGroupId: {}, userId: {}", studyId, userId); //로그확인
+
+        StudyGroup group = studyGroupRepository.findById(studyId)
+            .orElseThrow(() -> {
+                log.error("스터디 그룹이 존재하지 않음. ID: {}", studyId);
+                return new RuntimeException("스터디 그룹 없음");
+            });
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> {
+                log.error("사용자 없음. ID: {}", userId);
+                return new RuntimeException("사용자 없음");
+            });
+
+        log.info("유저와 그룹 조회 완료. 유저: {}, 그룹: {}", user.getNickname(), group.getName());
+
+        // 중복 체크
+        if (studyMemberRepository.existsByUserAndStudyGroup(user, group)) {
+            log.warn("이미 신청한 유저입니다.");
+            throw new StudyJoinException("이미 신청한 유저입니다.");
+        }
+        // 마감 지남
+        if (group.getDeadline().isBefore(LocalDateTime.now())) {
+            log.warn("스터디 마감일 초과 - 마감일: {}", group.getDeadline());
+            throw new StudyJoinException("스터디 모집 마감일이 지났습니다.");
+        }
+
+        int currentMembers = studyMemberRepository.countMembersByStudyGroup(group);
+        //인원초과
+        if(currentMembers == group.getLimit_members()) {
+            log.warn("스터디 인원 초과 - 현재: {}, 제한: {}", currentMembers, group.getLimit_members());
+            throw new StudyJoinException("스터디 정원이 초과되어 신청할 수 없습니다.");
+        }
+
+        StudyMember member = new StudyMember();
+        member.setUser(user);
+        member.setStudyGroup(group);
+        studyMemberRepository.save(member);
+
+        log.info("스터디 신청 저장 완료");
+    }
+}

--- a/src/test/java/com/example/study_monster_back/studyGroup/StudyMemberTests.java
+++ b/src/test/java/com/example/study_monster_back/studyGroup/StudyMemberTests.java
@@ -1,0 +1,100 @@
+package com.example.study_monster_back.studyGroup;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.study_monster_back.group.entity.StudyGroup;
+import com.example.study_monster_back.group.exception.StudyJoinException;
+import com.example.study_monster_back.group.repository.StudyGroupRepository;
+import com.example.study_monster_back.group.repository.StudyMemberRepository;
+import com.example.study_monster_back.group.service.StudyMemberServiceImpl;
+import com.example.study_monster_back.user.entity.User;
+import com.example.study_monster_back.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class StudyMemberTests {
+    @InjectMocks
+    private StudyMemberServiceImpl studyMemberService;
+
+    @Mock
+    private StudyGroupRepository studyGroupRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StudyMemberRepository studyMemberRepository;
+
+    private User mockUser;
+    private StudyGroup mockGroup;
+
+    @BeforeEach
+    void setup() {
+        mockUser = new User();
+        mockUser.setId(1L);
+        mockUser.setNickname("testuser");
+
+        mockGroup = new StudyGroup();
+        mockGroup.setId(1L);
+        mockGroup.setName("테스트스터디");
+        mockGroup.setDeadline(LocalDateTime.now().plusDays(1));
+        mockGroup.setLimit_members(5);
+    }
+
+    @Test
+    void 신청성공() {
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(mockGroup));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(studyMemberRepository.existsByUserAndStudyGroup(mockUser, mockGroup)).thenReturn(false);
+        when(studyMemberRepository.countMembersByStudyGroup(mockGroup)).thenReturn(3);
+
+        assertDoesNotThrow(() -> studyMemberService.join(1L, 1L));
+    }
+
+    @Test
+    void 이미신청() {
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(mockGroup));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(studyMemberRepository.existsByUserAndStudyGroup(mockUser, mockGroup)).thenReturn(true);
+
+        StudyJoinException e = assertThrows(StudyJoinException.class, () -> studyMemberService.join(1L, 1L));
+        assertEquals("이미 신청한 유저입니다.", e.getMessage());
+    }
+
+    @Test
+    void 데드라인지남() {
+        mockGroup.setDeadline(LocalDateTime.now().minusDays(1)); 
+
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(mockGroup));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(studyMemberRepository.existsByUserAndStudyGroup(mockUser, mockGroup)).thenReturn(false);
+
+        StudyJoinException e = assertThrows(StudyJoinException.class, () -> studyMemberService.join(1L, 1L));
+        assertEquals("스터디 모집 마감일이 지났습니다.", e.getMessage());
+    }
+
+    @Test
+    void 정원초과() {
+        when(studyGroupRepository.findById(1L)).thenReturn(Optional.of(mockGroup));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(mockUser));
+        when(studyMemberRepository.existsByUserAndStudyGroup(mockUser, mockGroup)).thenReturn(false);
+        when(studyMemberRepository.countMembersByStudyGroup(mockGroup)).thenReturn(5); 
+
+        StudyJoinException e = assertThrows(StudyJoinException.class, () -> studyMemberService.join(1L, 1L));
+        assertEquals("스터디 정원이 초과되어 신청할 수 없습니다.", e.getMessage());
+    }
+
+    
+}


### PR DESCRIPTION
## 작업 내용
- #21 과 연계되는 작업이 있어 그 위에서 브랜치를 생성하여 작업했습니다.
- 스터디 그룹 참여 로직을 구현하였습니다.
- group 폴더안에 exception 폴더를 생성했습니다.

## 연관된 이슈
- #28

## 스크린샷 (선택)
- 
![image](https://github.com/user-attachments/assets/9d5f32e4-069e-40f8-b379-564e0502ee66)


## 특이사항(선택)
> 로그인 연동 필요
